### PR TITLE
upgrade psycopg2-binary to v2.9.5

### DIFF
--- a/docs/flask/requirements.txt
+++ b/docs/flask/requirements.txt
@@ -8,7 +8,7 @@ itsdangerous==2.1.2; python_version >= '3.7'
 jinja2==3.1.2; python_version >= '3.7'
 markupsafe==2.1.1; python_version >= '3.7'
 packaging==21.3; python_version >= '3.6'
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.5
 pyparsing==3.0.9; python_full_version >= '3.6.8'
 redis==4.3.4
 setuptools==63.2.0; python_version >= '3.7'


### PR DESCRIPTION
`psycopg2-binary` in version `v2.9.3` seems to cause issues with the most current alpine flavored Python image resulting in the following acorn run output:
```
#0 1.893 Collecting psycopg2-binary==2.9.3
#0 1.906   Downloading psycopg2-binary-2.9.3.tar.gz (380 kB)
#0 1.935      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 380.6/380.6 kB 13.0 MB/s eta 0:00:00
#0 1.969   Preparing metadata (setup.py): started
#0 2.081   Preparing metadata (setup.py): finished with status 'error'
#0 2.085   error: subprocess-exited-with-error
#0 2.085
#0 2.085   × python setup.py egg_info did not run successfully.
#0 2.085   │ exit code: 1
#0 2.085   ╰─> [25 lines of output]
#0 2.085       /usr/local/lib/python3.11/site-packages/setuptools/config/setupcfg.py:508: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
#0 2.085         warnings.warn(msg, warning_class)
#0 2.085       running egg_info
#0 2.085       creating /tmp/pip-pip-egg-info-7sq134y7/psycopg2_binary.egg-info
#0 2.085       writing /tmp/pip-pip-egg-info-7sq134y7/psycopg2_binary.egg-info/PKG-INFO
#0 2.085       writing dependency_links to /tmp/pip-pip-egg-info-7sq134y7/psycopg2_binary.egg-info/dependency_links.txt
#0 2.085       writing top-level names to /tmp/pip-pip-egg-info-7sq134y7/psycopg2_binary.egg-info/top_level.txt
#0 2.085       writing manifest file '/tmp/pip-pip-egg-info-7sq134y7/psycopg2_binary.egg-info/SOURCES.txt'
#0 2.085
#0 2.085       Error: pg_config executable not found.
#0 2.085
#0 2.085       pg_config is required to build psycopg2 from source.  Please add the directory
#0 2.085       containing pg_config to the $PATH or specify the full executable path with the
#0 2.085       option:
#0 2.085
#0 2.085           python setup.py build_ext --pg-config /path/to/pg_config build ...
#0 2.085
#0 2.085       or with the pg_config option in 'setup.cfg'.
#0 2.085
#0 2.085       If you prefer to avoid building psycopg2 from source, please install the PyPI
#0 2.085       'psycopg2-binary' package instead.
#0 2.085
#0 2.085       For further information please check the 'doc/src/install.rst' file (also at
#0 2.085       <https://www.psycopg.org/docs/install.html>).
#0 2.085
#0 2.085       [end of output]
#0 2.085
#0 2.085   note: This error originates from a subprocess, and is likely not a problem with pip.
#0 2.086 error: metadata-generation-failed
#0 2.086
#0 2.086 × Encountered error while generating package metadata.
#0 2.086 ╰─> See above for output.
#0 2.086
#0 2.086 note: This is an issue with the package mentioned above, not pip.
#0 2.086 hint: See above for details.
#0 2.172
#0 2.172 [notice] A new release of pip available: 22.3 -> 22.3.1
#0 2.172 [notice] To update, run: pip install --upgrade pip
------
Error: failed to solve: process "/bin/sh -c pip install -r requirements.txt" did not complete successfully: exit code: 1
```

I managed to "fix" this error with a simple bump of `psycopg2-binary` to version `v2.9.5`. Now the demo is working again for me.